### PR TITLE
fix: middleware not able to find org membership

### DIFF
--- a/src/lib/actions/shared/get-current-org.ts
+++ b/src/lib/actions/shared/get-current-org.ts
@@ -33,7 +33,11 @@ export default async function getUserCurrentOrg(
     uid = data.user.id;
   }
 
-  const res = await supabase.from('roles').select('org_id').eq('user_id', uid);
+  const res = await supabase
+    .from('roles')
+    .select('org_id')
+    .eq('user_id', uid)
+    .limit(1);
 
   if (res.status !== 200 || !res.data) return '';
   return res.data[0].org_id;

--- a/src/lib/actions/shared/get-current-org.ts
+++ b/src/lib/actions/shared/get-current-org.ts
@@ -33,12 +33,8 @@ export default async function getUserCurrentOrg(
     uid = data.user.id;
   }
 
-  const res = await supabase
-    .from('roles')
-    .select('org_id')
-    .eq('user_id', uid)
-    .maybeSingle();
+  const res = await supabase.from('roles').select('org_id').eq('user_id', uid);
 
   if (res.status !== 200 || !res.data) return '';
-  return res.data.org_id;
+  return res.data[0].org_id;
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -3,6 +3,14 @@ import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import getUserCurrentOrg from '../actions/shared/get-current-org';
 
+// these routes require auth but no current org
+const NO_MEMBER_ROUTES = [
+  '/',
+  '/organization/no-member',
+  '/organization/create',
+  '/organization/join'
+];
+
 export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   let supabaseResponse = NextResponse.next({
@@ -10,7 +18,6 @@ export async function updateSession(request: NextRequest) {
   });
 
   const cookieStore = await cookies();
-
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -39,25 +46,28 @@ export async function updateSession(request: NextRequest) {
     data: { user }
   } = await supabase.auth.getUser();
 
+  // terminate early if no user of logging out
   if (!user || pathname.startsWith('/logout')) return supabaseResponse;
 
+  // if attempting to access an authed route with no org membership
   const currentOrg = cookieStore.get('current-org')?.value;
-  if (
-    !currentOrg &&
-    pathname !== '/' &&
-    !pathname.startsWith('/organization/no-member') &&
-    !pathname.startsWith('/organization/create') &&
-    !pathname.startsWith('/organization/join')
-  ) {
-    const currentOrgId = await getUserCurrentOrg(user.id);
-    if (!currentOrgId) {
+  if (!currentOrg && !NO_MEMBER_ROUTES.includes(pathname)) {
+    // find the first org theyre a member of
+    const orgId = await getUserCurrentOrg(user.id);
+
+    // if not a member of any org redirect to no member page
+    if (!orgId) {
       const url = request.nextUrl.clone();
       url.pathname = '/organization/no-member';
       return Response.redirect(url.toString());
     }
 
-    supabaseResponse.cookies.set('current-org', currentOrgId);
-  } else if (currentOrg) {
+    // otherwise set the cookie
+    supabaseResponse.cookies.set('current-org', orgId);
+  }
+  // if attempting to access any route with a cookie
+  else if (currentOrg) {
+    // ensure cookie is valid
     const res = await supabase
       .from('roles')
       .select('org_id')
@@ -65,6 +75,7 @@ export async function updateSession(request: NextRequest) {
       .eq('user_id', user.id)
       .maybeSingle();
 
+    // if not a memer delete the cookie
     if (!res.data) supabaseResponse.cookies.delete('current-org');
   }
 


### PR DESCRIPTION
This fix stems from a bug where the middleware would not be able to ascertain org membership when the cookie was not set.

It should be able to find  the first matching org in the DB a user is a member of and set the cookie as needed.

The reason this was a bug before is the  functionality of the `maybeSingle` function from supabase's PostgREST API. `maybeSingle` will error if more than a single result is found in the DB thus causing the helper to return a empty string and not being able to find a valid org.

For reference this method is needed instead of Drizzle because it needs to run the edge runtime since that's how the middleware is ran.

Also opted to add the functionality to set the cookie during login as well. 