### PR TITLE
fix: a myriad of small bugs

### DIFF
--- a/src/app/(auth)/confirm/error.tsx
+++ b/src/app/(auth)/confirm/error.tsx
@@ -5,14 +5,11 @@ interface ErrorProps {
   reset: () => void;
 }
 
-export default function Error(props: ErrorProps) {
-  const { error } = props;
-
+export default function Error(_props: ErrorProps) {
   return (
     <div className='flex size-full items-center justify-center'>
       <div>
         <h2 className='text-3xl font-bold'>Something went wrong!</h2>
-        <p>{error.message}</p>
       </div>
     </div>
   );

--- a/src/app/(auth)/confirm/page.tsx
+++ b/src/app/(auth)/confirm/page.tsx
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { type EmailOtpType } from '@supabase/supabase-js';
+import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createClient } from '#/lib/supabase/server';
 
@@ -30,5 +31,6 @@ export default async function ConfirmPage(props: ConfirmPageProps) {
   });
 
   if (error) throw new Error(error.message);
+  revalidatePath('/', 'layout');
   return redirect(next);
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,14 +1,23 @@
 import 'server-only';
 
 import { type Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
+import { createClient } from '#/lib/supabase/server';
 import LoginForm from './_components/login-form';
 
 export const metadata: Metadata = {
   title: 'Login'
 };
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const supabase = await createClient();
+  const {
+    data: { session }
+  } = await supabase.auth.getSession();
+
+  if (session !== null) return redirect('/dashboard');
+
   return (
     <Suspense>
       <LoginForm />

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,8 @@
 import 'server-only';
 
 import { type Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createClient } from '#/lib/supabase/server';
 import SignUpForm from './_components/sign-up-form';
 
 export const metadata: Metadata = {
@@ -8,6 +10,13 @@ export const metadata: Metadata = {
 };
 
 export default async function SignUpPage() {
+  const supabase = await createClient();
+  const {
+    data: { session }
+  } = await supabase.auth.getSession();
+
+  if (session !== null) return redirect('/dashboard');
+
   return (
     <div className='flex h-full flex-row items-center justify-center'>
       <SignUpForm />

--- a/src/app/(dashboard)/organization/_components/change-role-select.tsx
+++ b/src/app/(dashboard)/organization/_components/change-role-select.tsx
@@ -9,6 +9,7 @@ import {
 } from '#/components/ui/select';
 import { toast } from '#/components/ui/use-toast';
 import { RoleEnum } from '#/enums';
+import { cn } from '#/lib/utils';
 import revalidateAllPath from '#/revalidate-path';
 import { trpc, vanillaTRPC } from '#/trpc/query-clients/client';
 
@@ -55,9 +56,9 @@ export default function ChangeRoleSelect(props: ChangeRoleSelectProps) {
         description: `${type.slice(0, 1).toUpperCase() + type.slice(1)} role updated to ${role}`
       });
     },
-    onSettled: () => {
+    onSettled: (r) => {
       utils.org[type].list.invalidate();
-      revalidateAllPath();
+      if (r === RoleEnum.OWNER) revalidateAllPath();
     }
   });
 
@@ -73,11 +74,11 @@ export default function ChangeRoleSelect(props: ChangeRoleSelectProps) {
         <SelectItem value={RoleEnum.USER}>{RoleEnum.USER}</SelectItem>
         <SelectItem value={RoleEnum.EDITOR}>{RoleEnum.EDITOR}</SelectItem>
         <SelectItem value={RoleEnum.ADMIN}>{RoleEnum.ADMIN}</SelectItem>
-        {type === 'member' && (
-          <SelectItem disabled={!allowOwnerSelect} value={RoleEnum.OWNER}>
-            {RoleEnum.OWNER}
-          </SelectItem>
-        )}
+        <SelectItem
+          className={cn((!allowOwnerSelect || type === 'invite') && 'hidden')}
+          value={RoleEnum.OWNER}>
+          {RoleEnum.OWNER}
+        </SelectItem>
       </SelectContent>
     </Select>
   );

--- a/src/app/(dashboard)/organization/_components/change-role-select.tsx
+++ b/src/app/(dashboard)/organization/_components/change-role-select.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -8,6 +9,7 @@ import {
 } from '#/components/ui/select';
 import { toast } from '#/components/ui/use-toast';
 import { RoleEnum } from '#/enums';
+import revalidateAllPath from '#/revalidate-path';
 import { trpc, vanillaTRPC } from '#/trpc/query-clients/client';
 
 interface ChangeRoleSelectProps {
@@ -16,21 +18,31 @@ interface ChangeRoleSelectProps {
   currentRole: RoleEnum;
   orgId: string;
   disabled?: boolean;
+  allowOwnerSelect?: boolean;
 }
 
 export default function ChangeRoleSelect(props: ChangeRoleSelectProps) {
-  const { currentRole, id, orgId, type, disabled = false } = props;
+  const {
+    currentRole,
+    id,
+    orgId,
+    type,
+    disabled = false,
+    allowOwnerSelect = false
+  } = props;
 
+  const [value, setValue] = useState<RoleEnum>(currentRole);
   const utils = trpc.useUtils();
   const { mutate } = useMutation({
     mutationFn: async (role: RoleEnum) => {
+      setValue(role);
       await (type === 'member'
         ? vanillaTRPC.org.member.update.mutate({ userId: id, orgId, role })
         : vanillaTRPC.org.invite.update.mutate({ inviteId: id, orgId, role }));
-
       return role;
     },
     onError: (data) => {
+      setValue(currentRole);
       toast({
         variant: 'destructive',
         title: `Failed to update ${type}`,
@@ -39,26 +51,33 @@ export default function ChangeRoleSelect(props: ChangeRoleSelectProps) {
     },
     onSuccess: async (role) => {
       toast({
-        title: `${type.slice(0, 1).toUpperCase() + type.slice(1)} role updated to ${role}`
+        title: `Updated ${type}`,
+        description: `${type.slice(0, 1).toUpperCase() + type.slice(1)} role updated to ${role}`
       });
+    },
+    onSettled: () => {
       utils.org[type].list.invalidate();
+      revalidateAllPath();
     }
   });
 
   return (
     <Select
       disabled={disabled}
-      defaultValue={currentRole}
+      value={value}
       onValueChange={(d) => mutate(d as RoleEnum)}>
       <SelectTrigger className='h-auto w-[80px] border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-800 hover:text-green-600'>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {Object.values(RoleEnum).map((r) => (
-          <SelectItem key={r} value={r}>
-            {r}
+        <SelectItem value={RoleEnum.USER}>{RoleEnum.USER}</SelectItem>
+        <SelectItem value={RoleEnum.EDITOR}>{RoleEnum.EDITOR}</SelectItem>
+        <SelectItem value={RoleEnum.ADMIN}>{RoleEnum.ADMIN}</SelectItem>
+        {type === 'member' && (
+          <SelectItem disabled={!allowOwnerSelect} value={RoleEnum.OWNER}>
+            {RoleEnum.OWNER}
           </SelectItem>
-        ))}
+        )}
       </SelectContent>
     </Select>
   );

--- a/src/app/(dashboard)/organization/_components/user-table.tsx
+++ b/src/app/(dashboard)/organization/_components/user-table.tsx
@@ -29,8 +29,9 @@ export default function UserTable(props: UserTableProps) {
   const memberQuery = trpc.org.member.list.useQuery({ orgId });
   const inviteQuery = trpc.org.invite.list.useQuery({ orgId });
 
-  const hasAdminPriv =
-    ADMIN_SET.intersection(new Set(currentUserRoles)).size >= 1;
+  const currentRoleSet = new Set(currentUserRoles);
+  const hasAdminPriv = ADMIN_SET.intersection(currentRoleSet).size >= 1;
+  const isOwner = currentRoleSet.has(RoleEnum.OWNER);
 
   return (
     <DataTable
@@ -94,6 +95,7 @@ export default function UserTable(props: UserTableProps) {
                 type={row.original.type}
                 id={row.original.id}
                 currentRole={row.original.role}
+                allowOwnerSelect={isOwner}
               />
             ) : (
               <p className='font-normal text-gray-500'>{row.original.role}</p>

--- a/src/lib/server/shared/get-current-org.ts
+++ b/src/lib/server/shared/get-current-org.ts
@@ -40,6 +40,7 @@ export default async function getUserCurrentOrg(
     .from('roles')
     .select('org_id')
     .eq('user_id', uid)
+    .eq('active', true)
     .limit(1);
 
   const orgId =

--- a/src/lib/server/shared/get-org-membership.ts
+++ b/src/lib/server/shared/get-org-membership.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createClient } from '../../supabase/server';
+
+interface DB {
+  public: {
+    Tables: {
+      roles: {
+        Row: {
+          user_id: string;
+          org_id: string;
+          active: boolean;
+        };
+      };
+    };
+  };
+}
+
+/**
+ * Pure function to get set of orgs a user is a member of
+ */
+export default async function getOrgMembership(
+  userId?: string
+): Promise<Set<string>> {
+  let uid = userId;
+
+  try {
+    const supabase = await createClient<DB>();
+    if (!uid) {
+      const { error, data } = await supabase.auth.getUser();
+
+      if (error || !data.user) return redirect('/login');
+      uid = data.user.id;
+    }
+
+    // use postgrest for edge runtime
+    const res = await supabase
+      .from('roles')
+      .select('org_id')
+      .eq('user_id', uid)
+      .eq('active', true);
+
+    const orgList =
+      res.status !== 200 || !res.data || res.data.length === 0
+        ? []
+        : res.data.map((o) => o.org_id);
+
+    return new Set(orgList);
+  } catch {
+    return new Set([]);
+  }
+}

--- a/src/trpc/routes/org/org-invite-update.ts
+++ b/src/trpc/routes/org/org-invite-update.ts
@@ -10,7 +10,10 @@ import { authProcedure } from '#/trpc/init';
 const updateInviteInput = z.object({
   inviteId: z.string().uuid(),
   orgId: z.string().uuid(),
-  role: z.nativeEnum(RoleEnum).optional()
+  role: z
+    .nativeEnum(RoleEnum)
+    .optional()
+    .refine((v) => v !== RoleEnum.OWNER, 'Invite cannot be set to Owner')
 });
 
 export const updateInvite = authProcedure

--- a/src/trpc/routes/org/org-member-update.ts
+++ b/src/trpc/routes/org/org-member-update.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { and, eq } from 'drizzle-orm';
 import { createSelectSchema } from 'drizzle-zod';
 import { db } from '#/db';
-import { roles } from '#/db/schema/public';
+import { organizations, roles } from '#/db/schema/public';
 import { RoleEnum } from '#/enums';
 import authCheck from '#/lib/server/shared/auth-check';
 import { authProcedure } from '#/trpc/init';
@@ -17,24 +17,64 @@ export const updateRole = authProcedure
     const { user } = opts.ctx;
     const { userId, orgId, ...rest } = opts.input;
 
+    const isSameUser = userId === user.id;
     const auth = await authCheck({
       user,
       orgId,
       rolesNeeded: [RoleEnum.OWNER, RoleEnum.ADMIN]
     });
+
     if (!auth.ok)
       throw new TRPCError({
         code: 'UNAUTHORIZED',
         message: auth.message
       });
 
-    await db
-      .update(roles)
-      .set({
-        role: rest.role,
-        active: rest.active
-      })
-      .where(and(eq(roles.orgId, orgId), eq(roles.userId, userId)));
+    if (rest.role === RoleEnum.OWNER && !auth.data.roles.has(RoleEnum.OWNER))
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User does not have access to this action'
+      });
+
+    const isOwner = auth.data.roles.has(RoleEnum.OWNER);
+    if (isSameUser && isOwner) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'User must first transfer ownership'
+      });
+    }
+
+    const userToAugment = await db.query.roles.findFirst({
+      columns: { role: true },
+      where: (r, { eq, and }) => and(eq(r.userId, userId), eq(r.orgId, orgId))
+    });
+
+    if (userToAugment?.role === RoleEnum.OWNER && !isOwner) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User does not have access to this resource'
+      });
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(roles)
+        .set(rest)
+        .where(and(eq(roles.orgId, orgId), eq(roles.userId, userId)));
+
+      if (!isOwner || rest.role !== RoleEnum.OWNER) return;
+
+      // transfer ownership
+      await tx
+        .update(roles)
+        .set({ role: RoleEnum.ADMIN })
+        .where(and(eq(roles.orgId, orgId), eq(roles.userId, user.id)));
+
+      await tx
+        .update(organizations)
+        .set({ ownerId: userId })
+        .where(eq(organizations.id, orgId));
+    });
 
     return { ok: true };
   });

--- a/src/trpc/schemas.ts
+++ b/src/trpc/schemas.ts
@@ -23,7 +23,9 @@ type InviteInsertSchema = z.ZodSchema<
 export const createInviteInput = z.object({
   orgId: z.string().uuid(),
   email: z.string().email(),
-  role: z.nativeEnum(RoleEnum)
+  role: z
+    .nativeEnum(RoleEnum)
+    .refine((v) => v !== RoleEnum.OWNER, 'Invite cannot be set to Owner')
 }) satisfies InviteInsertSchema;
 
 export const signUpInput = z


### PR DESCRIPTION
Fixes / Relates to [issue link]

Changes:
- middleware is more strict about the value of the org cookie
   - With now check to ensure the user is indeed a member of a given org
   - Added new helper to return a set of orgIds the user is in for this 
- `authCheck` helper will now return a set of roles the user has when supplied an `orgId`
   - Works the same otherwise
- `getCurrentOrg` helper adds check that the user must be activated in the role table to be considered a member of an org
- Add guard rails to RBAC operations
   - Owners cannot leave or deactivate themselves until they had transferred ownership to another user
   - Admins cannot set other users as owners 
   - Comes with UI changes in the role select UI element to hide show options
- Invites cannot be set to the Owner role
   - API no longer accepts this as a valid role value    
- Confirm page will revalidate layout of stale data
-  Login and signup check if theres a current user session. If so they redirect to the dashboard page
